### PR TITLE
Config settings accepts blocks which are evaluated once

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ module VersionMixin
   extend Usable
   config.max_versions = 25
   config.table_name = 'versions'
+  config.model { Audit }
   
   def save_version
     "Saving #{usables.max_versions} #{usables.table_name}"

--- a/bin/console
+++ b/bin/console
@@ -61,6 +61,7 @@ class Example
   usable Mixin
   usable VersionMixin do
     max_versions 10
+    model { Model }
   end
   usable Nested::Extension
 end

--- a/lib/usable/config.rb
+++ b/lib/usable/config.rb
@@ -1,8 +1,12 @@
+require 'usable/config_multi'
+require 'usable/config_register'
+
 module Usable
   # Store and manage configuration settings. Keep methods to a minimum since this class relies on method_missing to read
   # and write to the underlying @spec object
   class Config
-    include ModConfig
+    include ConfigRegister
+    include ConfigMulti
 
     def initialize
       @spec = OpenStruct.new
@@ -16,8 +20,13 @@ module Usable
       if value
         @spec[key.to_s.tr('=', '')] = value
       else
-        @spec[key]
+        # Handle the case where the value may be defined with a block, in which case it's a method
+        @spec[key] ||= call_lazy_method(key)
       end
+    end
+
+    def _spec
+      @spec
     end
 
     def [](key)
@@ -28,14 +37,22 @@ module Usable
       spec key, val
     end
 
-    def method_missing(method_name, *args)
-      spec method_name, *args
-    rescue
+    def call_lazy_method(key)
+      @spec.public_send(key.to_s.tr('=', ''))
+    end
+
+    def method_missing(method_name, *args, &block)
+      if block
+        _spec.define_singleton_method(method_name) { yield }
+      else
+        spec method_name, *args
+      end
+    rescue => e
       super
     end
 
     def respond_to_missing?(method_name, _private = false)
-      method_name.to_s.end_with?('=') || @spec.respond_to?(method_name)
+      method_name.to_s.end_with?('=') || _spec.respond_to?(method_name)
     end
   end
 end

--- a/lib/usable/config_multi.rb
+++ b/lib/usable/config_multi.rb
@@ -1,0 +1,19 @@
+module Usable
+  module ConfigMulti
+    # It's important to define all block specs we need to lazy load
+    # Set block specs to nil values so it will fallback to calling the underlying singleton method defined by Config#method_missing
+    def +(other)
+      config = clone
+      specs = other._spec.to_h
+      specs.each { |key, val| config.spec key, val }
+      methods = other._spec.singleton_methods - specs.keys
+      methods.each do |name|
+        config._spec[name] = nil
+        config._spec.define_singleton_method(name) do
+          other._spec.singleton_method(name).call
+        end
+      end
+      config
+    end
+  end
+end

--- a/lib/usable/config_register.rb
+++ b/lib/usable/config_register.rb
@@ -1,6 +1,7 @@
 module Usable
   # Keep track of "used" modules and their "available" methods
-  module ModConfig
+  # Mixin for Config
+  module ConfigRegister
     def available_methods
       modules.each_with_object(Hash.new(Null.instance_method(:default_method))) do |mod, result|
         mod.instance_methods.each do |method_name|

--- a/lib/usable/mod_extender.rb
+++ b/lib/usable/mod_extender.rb
@@ -18,7 +18,9 @@ module Usable
     # @description Directly include a module whose methods you want made available in +usables.available_methods+
     #   Gives the module a name when including so that it shows up properly in the list of ancestors
     def call(target)
-      override
+      unwanted.each do |method_name|
+        copy.send :remove_method, method_name
+      end
       if copy.name.nil?
         const_name = "#{mod_name}Used"
         target.send :remove_const, const_name if target.const_defined? const_name, false
@@ -26,25 +28,6 @@ module Usable
       end
       target.usables.add_module copy
       target.send options[:method], copy
-    end
-
-    # @note Destructive, as it changes @copy
-    def override
-      unwanted.each do |method_name|
-        copy.send :remove_method, method_name
-      end
-    end
-
-    # @description Extends the target with the module's ClassMethod mod
-    def use_class_methods!(target)
-      return unless mod.const_defined? :ClassMethods
-      target.extend mod.const_get :ClassMethods
-    end
-
-    # @description Extends the target with the module's ClassMethod mod
-    def use_instance_methods!(target)
-      return unless mod.const_defined? :InstanceMethods
-      target.include mod.const_get :InstanceMethods
     end
 
     def mod_name

--- a/spec/lib/usable/config_spec.rb
+++ b/spec/lib/usable/config_spec.rb
@@ -31,6 +31,19 @@ describe Usable::Config do
     end
   end
 
+  describe 'when defining a value with a block' do
+    it "saves block and evaluates the first time it's called, returning the value" do
+      expect(subject).to_not respond_to(:foo)
+      n = 10
+      subject.foo { n }
+      n += 5
+      expect(subject.foo).to eq 15
+      n += 5
+      # it should be memoized at this point
+      expect(subject.foo).to eq 15
+    end
+  end
+
   describe '#respond_to(_missing)?' do
     context 'when the given -name- ends with "="' do
       it 'returns true' do


### PR DESCRIPTION
Blocks are evaluated continuously if they return nil. But why would anyone set nil as a usable value, with a block? That would seem like a bug
