### PR TITLE
V3

### DIFF
--- a/lib/usable.rb
+++ b/lib/usable.rb
@@ -20,19 +20,21 @@ module Usable
         end
       end
     else
+      # Define +config+ when added to a module
       base.instance_eval do
         def config(&block)
-          usables(&block)
+          if block
+            usables.instance_eval &block
+          else
+            usables
+          end
         end unless defined? config
       end
     end
   end
 
-  # @description Read and write configuration options
   def usables
     @usables ||= Config.new
-    return @usables unless block_given?
-    @usables.instance_eval &Proc.new
   end
 
   attr_writer :usables

--- a/lib/usable/config.rb
+++ b/lib/usable/config.rb
@@ -47,7 +47,7 @@ module Usable
       else
         spec method_name, *args
       end
-    rescue => e
+    rescue NoMethodError
       super
     end
 

--- a/spec/lib/usable/config_spec.rb
+++ b/spec/lib/usable/config_spec.rb
@@ -44,6 +44,18 @@ describe Usable::Config do
     end
   end
 
+  describe '#method_missing' do
+    context 'when an unknown error occurs' do
+      before { subject.model { UndefinedModel } }
+
+      it 'raises the appropriate error' do
+        expect {
+          subject.model
+        }.to raise_error(NameError, 'uninitialized constant UndefinedModel')
+      end
+    end
+  end
+
   describe '#respond_to(_missing)?' do
     context 'when the given -name- ends with "="' do
       it 'returns true' do

--- a/spec/lib/usable_spec.rb
+++ b/spec/lib/usable_spec.rb
@@ -391,7 +391,7 @@ describe Usable do
   describe 'copying usables when extending a usable module' do
     before do
       mod.extend Usable
-      mod.usables do
+      mod.config do
         host 'localhost'
       end
     end

--- a/spec/lib/usable_spec.rb
+++ b/spec/lib/usable_spec.rb
@@ -86,6 +86,27 @@ describe Usable do
       expect(subject.usable(mod)).to be subject
     end
 
+    context 'when given multiple modules' do
+      before do
+        mod.extend Usable
+        mod.config do
+          versions_size 10
+        end
+        instance_mod.extend Usable
+        instance_mod.config do
+          instance_size 15
+        end
+        subject.usable mod, instance_mod
+      end
+
+      it 'uses all the modules' do
+        expect(subject.new).to respond_to(:versions)
+        expect(subject.new).to respond_to(:from_instance_mod)
+        expect(subject.usables.versions_size).to eq 10
+        expect(subject.usables.instance_size).to eq 15
+      end
+    end
+
     context "when block_given?" do
       it "yields @usables to the given block" do
         expect {


### PR DESCRIPTION
Drop support for `usables(&block` because it's slow and is rarely (if ever) used in the wild.

```ruby
N = 100_000
Benchmark.bmbm do |x|
  x.report('old') do
    N.times { Example.usables_old }
  end
  x.report('new') do
    N.times { Example.usables }
  end
end
```
```bash
Rehearsal ---------------------------------------
old   0.130000   0.000000   0.130000 (  0.133862)
new   0.100000   0.000000   0.100000 (  0.096258)
------------------------------ total: 0.230000sec

          user     system      total        real
old   0.130000   0.000000   0.130000 (  0.130268)
new   0.090000   0.000000   0.090000 (  0.095871)
```